### PR TITLE
feat: basic applicator input

### DIFF
--- a/.aider-current-task.md
+++ b/.aider-current-task.md
@@ -12,5 +12,8 @@ Each applicator has the following fields:
 - [x] Create a new widget called `NewApplicatorPage`
 - [x] Trigger `NewApplicatorPage` from the add button callback in the applicator page
 - [x] Hide the Add button if `onAddPressed == null`
-- [ ] Add the name input to the `NewApplicatorPage`
-- [ ] Add the License number input to the `NewApplicatorPage`
+- [x] Add the name input to the `NewApplicatorPage`
+- [x] Add the License number input to the `NewApplicatorPage`
+- [x] Add a save button to the app bar of `NewApplicatorPage`
+- [x] Close the `NewApplicatorPage` when the user clicks the save button
+- [ ] If the user tries to leave the `NewApplicatorPage` without saving, prompt them with "Are you sure? You will lose unsaved changes."

--- a/.aider-current-task.md
+++ b/.aider-current-task.md
@@ -6,7 +6,7 @@ Each applicator has the following fields:
 
 ## Steps
 
-- [ ] Add a callback to `TopLevelPage` that is triggered when the Add button is pressed.
+- [x] Add a callback to `TopLevelPage` that is triggered when the Add button is pressed.
 - [ ] Use the callback instead of showing the Coming Soon dialog
 - [ ] Print "Hello" from the applicators page when the add button is pressed
 - [ ] Create a new widget called `NewApplicatorPage`

--- a/.aider-current-task.md
+++ b/.aider-current-task.md
@@ -7,9 +7,10 @@ Each applicator has the following fields:
 ## Steps
 
 - [x] Add a callback to `TopLevelPage` that is triggered when the Add button is pressed.
-- [ ] Use the callback instead of showing the Coming Soon dialog
-- [ ] Print "Hello" from the applicators page when the add button is pressed
-- [ ] Create a new widget called `NewApplicatorPage`
-- [ ] Trigger `NewApplicatorPage` from the add button callback in the applicator page
+- [x] Use the callback instead of showing the Coming Soon dialog
+- [x] Print "Hello" from the applicators page when the add button is pressed
+- [x] Create a new widget called `NewApplicatorPage`
+- [x] Trigger `NewApplicatorPage` from the add button callback in the applicator page
+- [x] Hide the Add button if `onAddPressed == null`
 - [ ] Add the name input to the `NewApplicatorPage`
 - [ ] Add the License number input to the `NewApplicatorPage`

--- a/.aider-current-task.md
+++ b/.aider-current-task.md
@@ -1,0 +1,15 @@
+Create basic input form that allows entering applicator info in the app
+
+Each applicator has the following fields:
+- Name
+- License number
+
+## Steps
+
+- [ ] Add a callback to `TopLevelPage` that is triggered when the Add button is pressed.
+- [ ] Use the callback instead of showing the Coming Soon dialog
+- [ ] Print "Hello" from the applicators page when the add button is pressed
+- [ ] Create a new widget called `NewApplicatorPage`
+- [ ] Trigger `NewApplicatorPage` from the add button callback in the applicator page
+- [ ] Add the name input to the `NewApplicatorPage`
+- [ ] Add the License number input to the `NewApplicatorPage`

--- a/.aider-current-task.md
+++ b/.aider-current-task.md
@@ -1,19 +1,6 @@
-Create basic input form that allows entering applicator info in the app
-
-Each applicator has the following fields:
-- Name
-- License number
+You can copy and paste the contents of your current GitHub issue here so Aider knows what to work on!
 
 ## Steps
 
-- [x] Add a callback to `TopLevelPage` that is triggered when the Add button is pressed.
-- [x] Use the callback instead of showing the Coming Soon dialog
-- [x] Print "Hello" from the applicators page when the add button is pressed
-- [x] Create a new widget called `NewApplicatorPage`
-- [x] Trigger `NewApplicatorPage` from the add button callback in the applicator page
-- [x] Hide the Add button if `onAddPressed == null`
-- [x] Add the name input to the `NewApplicatorPage`
-- [x] Add the License number input to the `NewApplicatorPage`
-- [x] Add a save button to the app bar of `NewApplicatorPage`
-- [x] Close the `NewApplicatorPage` when the user clicks the save button
-- [ ] If the user tries to leave the `NewApplicatorPage` without saving, prompt them with "Are you sure? You will lose unsaved changes."
+- [x] Check off steps as you complete them
+- [ ] Add some steps here

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.env
 .aider*
+!.aider-current-task.md

--- a/app/lib/applicators_page.dart
+++ b/app/lib/applicators_page.dart
@@ -3,14 +3,12 @@ import 'top_level_page.dart';
 import 'new_applicator_page.dart';
 
 class ApplicatorsPage extends StatelessWidget {
-  const ApplicatorsPage({Key? key}) : super(key: key);
+  const ApplicatorsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return TopLevelPage(
-      body: const Center(
-        child: Text('Applicators Page Content'),
-      ),
+      body: const Center(child: Text('Applicators Page Content')),
       onAddPressed: () {
         Navigator.push(
           context,

--- a/app/lib/applicators_page.dart
+++ b/app/lib/applicators_page.dart
@@ -8,7 +8,7 @@ class ApplicatorsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TopLevelPage(
-      body: const Center(child: Text('Applicators Page Content')),
+      body: ListView(),
       onAddPressed: () {
         Navigator.push(
           context,

--- a/app/lib/applicators_page.dart
+++ b/app/lib/applicators_page.dart
@@ -1,9 +1,22 @@
 import 'package:flutter/material.dart';
 import 'top_level_page.dart';
+import 'new_applicator_page.dart';
 
 class ApplicatorsPage extends StatelessWidget {
-  const ApplicatorsPage({super.key});
+  const ApplicatorsPage({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) => TopLevelPage(body: ListView());
+  Widget build(BuildContext context) {
+    return TopLevelPage(
+      body: const Center(
+        child: Text('Applicators Page Content'),
+      ),
+      onAddPressed: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const NewApplicatorPage()),
+        );
+      },
+    );
+  }
 }

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -8,7 +8,6 @@ class NewApplicatorPage extends StatefulWidget {
 }
 
 class _NewApplicatorPageState extends State<NewApplicatorPage> {
-  @override
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -12,7 +12,7 @@ class NewApplicatorPage extends StatelessWidget {
           IconButton(
             icon: const Icon(Icons.save),
             onPressed: () {
-              // TODO: Implement save functionality
+              Navigator.pop(context);
             },
           ),
         ],

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -17,13 +17,15 @@ class NewApplicatorPage extends StatelessWidget {
                     ),
                     actions: <Widget>[
                       TextButton(
-                        onPressed: () => Navigator.of(context).pop(false),
-                        child: const Text('Stay'),
+                        onPressed: () => Navigator.of(context).pop(true),
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.red,
+                        ),
+                        child: const Text('Leave'),
                       ),
                       TextButton(
-                        onPressed: () => Navigator.of(context).pop(true),
-                        style: TextButton.styleFrom(foregroundColor: Colors.red),
-                        child: const Text('Leave'),
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: const Text('Stay'),
                       ),
                     ],
                   ),

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class NewApplicatorPage extends StatelessWidget {
+  const NewApplicatorPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('New Applicator'),
+      ),
+      body: const Center(
+        child: Text('New Applicator Page'),
+      ),
+    );
+  }
+}

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -12,6 +12,7 @@ class NewApplicatorPage extends StatelessWidget {
           IconButton(
             icon: const Icon(Icons.save),
             onPressed: () {
+              // TODO: actually save the form input
               Navigator.pop(context);
             },
           ),
@@ -20,6 +21,7 @@ class NewApplicatorPage extends StatelessWidget {
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
+          spacing: 16,
           children: [
             TextFormField(
               decoration: const InputDecoration(
@@ -27,7 +29,6 @@ class NewApplicatorPage extends StatelessWidget {
                 border: OutlineInputBorder(),
               ),
             ),
-            const SizedBox(height: 16.0),
             TextFormField(
               decoration: const InputDecoration(
                 labelText: 'License Number',

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -17,6 +17,13 @@ class NewApplicatorPage extends StatelessWidget {
                 border: OutlineInputBorder(),
               ),
             ),
+            const SizedBox(height: 16.0),
+            TextFormField(
+              decoration: const InputDecoration(
+                labelText: 'License Number',
+                border: OutlineInputBorder(),
+              ),
+            ),
           ],
         ),
       ),

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -1,33 +1,31 @@
 import 'package:flutter/material.dart';
 
-class NewApplicatorPage extends StatefulWidget {
+class NewApplicatorPage extends StatelessWidget {
   const NewApplicatorPage({super.key});
 
   @override
-  State<NewApplicatorPage> createState() => _NewApplicatorPageState();
-}
-
-class _NewApplicatorPageState extends State<NewApplicatorPage> {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
         return await showDialog(
               context: context,
-              builder: (context) => AlertDialog(
-                title: const Text('Are you sure?'),
-                content: const Text(
-                    'Are you sure you want to leave? You will lose unsaved changes.'),
-                actions: <Widget>[
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(false),
-                    child: const Text('Stay'),
+              builder:
+                  (context) => AlertDialog(
+                    title: const Text('Are you sure?'),
+                    content: const Text(
+                      'Are you sure you want to leave? You will lose unsaved changes.',
+                    ),
+                    actions: <Widget>[
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: const Text('Stay'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(true),
+                        child: const Text('Leave'),
+                      ),
+                    ],
                   ),
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(true),
-                    child: const Text('Leave'),
-                  ),
-                ],
-              ),
             ) ??
             false;
       },

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -1,41 +1,69 @@
 import 'package:flutter/material.dart';
 
-class NewApplicatorPage extends StatelessWidget {
+class NewApplicatorPage extends StatefulWidget {
   const NewApplicatorPage({super.key});
 
   @override
+  State<NewApplicatorPage> createState() => _NewApplicatorPageState();
+}
+
+class _NewApplicatorPageState extends State<NewApplicatorPage> {
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('New Applicator'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.save),
-            onPressed: () {
-              // TODO: actually save the form input
-              Navigator.pop(context);
-            },
-          ),
-        ],
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          spacing: 16,
-          children: [
-            TextFormField(
-              decoration: const InputDecoration(
-                labelText: 'Name',
-                border: OutlineInputBorder(),
+    return WillPopScope(
+      onWillPop: () async {
+        return await showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('Are you sure?'),
+                content: const Text(
+                    'Are you sure you want to leave? You will lose unsaved changes.'),
+                actions: <Widget>[
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const Text('Stay'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: const Text('Leave'),
+                  ),
+                ],
               ),
-            ),
-            TextFormField(
-              decoration: const InputDecoration(
-                labelText: 'License Number',
-                border: OutlineInputBorder(),
-              ),
+            ) ??
+            false;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('New Applicator'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.save),
+              onPressed: () {
+                // TODO: actually save the form input
+                Navigator.pop(context);
+              },
             ),
           ],
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            spacing: 16,
+            children: [
+              TextFormField(
+                decoration: const InputDecoration(
+                  labelText: 'Name',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  labelText: 'License Number',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -22,6 +22,7 @@ class NewApplicatorPage extends StatelessWidget {
                       ),
                       TextButton(
                         onPressed: () => Navigator.of(context).pop(true),
+                        style: TextButton.styleFrom(foregroundColor: Colors.red),
                         child: const Text('Leave'),
                       ),
                     ],

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -7,7 +7,19 @@ class NewApplicatorPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('New Applicator')),
-      body: const Center(child: Text('New Applicator Page')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextFormField(
+              decoration: const InputDecoration(
+                labelText: 'Name',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -6,7 +6,17 @@ class NewApplicatorPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('New Applicator')),
+      appBar: AppBar(
+        title: const Text('New Applicator'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: () {
+              // TODO: Implement save functionality
+            },
+          ),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/app/lib/new_applicator_page.dart
+++ b/app/lib/new_applicator_page.dart
@@ -1,17 +1,13 @@
 import 'package:flutter/material.dart';
 
 class NewApplicatorPage extends StatelessWidget {
-  const NewApplicatorPage({Key? key}) : super(key: key);
+  const NewApplicatorPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('New Applicator'),
-      ),
-      body: const Center(
-        child: Text('New Applicator Page'),
-      ),
+      appBar: AppBar(title: const Text('New Applicator')),
+      body: const Center(child: Text('New Applicator Page')),
     );
   }
 }

--- a/app/lib/top_level_page.dart
+++ b/app/lib/top_level_page.dart
@@ -4,18 +4,19 @@ import 'package:iconify_flutter/icons/mdi.dart';
 import 'coming_soon_dialog.dart';
 
 class TopLevelPage extends StatelessWidget {
-  const TopLevelPage({super.key, required this.body});
+  const TopLevelPage({super.key, required this.body, this.onAddPressed});
 
   final Widget body;
+  final VoidCallback? onAddPressed;
 
   @override
   Widget build(BuildContext context) => Scaffold(
     body: body,
     floatingActionButton: FloatingActionButton(
-      onPressed: () {
+      onPressed: onAddPressed ?? () {
         showDialog(
           context: context,
-          builder: (BuildContext context) => ComingSoonDialog(),
+          builder: (BuildContext context) => const ComingSoonDialog(),
         );
       },
       child: Iconify(Mdi.add),

--- a/app/lib/top_level_page.dart
+++ b/app/lib/top_level_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:iconify_flutter/iconify_flutter.dart';
 import 'package:iconify_flutter/icons/mdi.dart';
-import 'coming_soon_dialog.dart';
 
 class TopLevelPage extends StatelessWidget {
   const TopLevelPage({super.key, required this.body, this.onAddPressed});
@@ -12,9 +11,12 @@ class TopLevelPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
     body: body,
-    floatingActionButton: onAddPressed != null ? FloatingActionButton(
-      onPressed: onAddPressed,
-      child: Iconify(Mdi.add),
-    ) : null,
+    floatingActionButton:
+        onAddPressed != null
+            ? FloatingActionButton(
+              onPressed: onAddPressed,
+              child: Iconify(Mdi.add),
+            )
+            : null,
   );
 }

--- a/app/lib/top_level_page.dart
+++ b/app/lib/top_level_page.dart
@@ -12,14 +12,9 @@ class TopLevelPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Scaffold(
     body: body,
-    floatingActionButton: FloatingActionButton(
-      onPressed: onAddPressed ?? () {
-        showDialog(
-          context: context,
-          builder: (BuildContext context) => const ComingSoonDialog(),
-        );
-      },
+    floatingActionButton: onAddPressed != null ? FloatingActionButton(
+      onPressed: onAddPressed,
       child: Iconify(Mdi.add),
-    ),
+    ) : null,
   );
 }


### PR DESCRIPTION
This does not actually do anything with data. For now I am just playing with the general UI structure.

## Future Ideas

- Instead of having a dedicated "New Applicator" component, we should just have one "Edit Applicator" component
- When the user taps the "Add" button from the Applicators page, it should create a new row in the DB immediately with draft values, then open the "Edit Applicator" for that new row.
    - This way the user never loses any new changes.
    - This will be especially important when we get to the "New Record" component, because there will be many form input and we don't want the user to accidentally use data. It will be better to have some sort of "Draft" system.