### PR TITLE
fix: close the modal when editing a record

### DIFF
--- a/app/lib/records_page.dart
+++ b/app/lib/records_page.dart
@@ -75,10 +75,10 @@ class _RecordsPageState extends State<RecordsPage> {
 }
 
 class RecordTile extends StatelessWidget {
-  const RecordTile({super.key, required this.record, this.onEdit});
+  const RecordTile({super.key, required this.record, required this.onEdit});
 
   final Record record;
-  final VoidCallback? onEdit;
+  final VoidCallback onEdit;
 
   @override
   Widget build(BuildContext context) {
@@ -104,7 +104,10 @@ class RecordTile extends StatelessWidget {
                 ListTile(
                   leading: Iconify(Mdi.edit),
                   title: const Text('Edit'),
-                  onTap: onEdit,
+                  onTap: () {
+                    Navigator.pop(context);
+                    onEdit();
+                  },
                 ),
                 ListTile(
                   leading: Iconify(Mdi.file_pdf),


### PR DESCRIPTION
There was a bug from #40 where the Record modal doesn't close when you click the "Edit" option.

Thanks to my wife for highlighting this one 😁 