### PR TITLE
feat: data import

### DIFF
--- a/app/lib/data_importer.dart
+++ b/app/lib/data_importer.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:karriba/database_helper.dart';
+
+Future<void> importDatabase(BuildContext context) async {
+  bool? importConfirmed = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext context) {
+      final importCodeController = TextEditingController();
+      bool importButtonEnabled = false;
+
+      return StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return AlertDialog(
+            title: const Text('Import Data?'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'This will overwrite all existing data. Type "import" to continue.',
+                ),
+                TextFormField(
+                  controller: importCodeController,
+                  decoration: const InputDecoration(
+                    hintText: 'Type "import" here',
+                  ),
+                  onChanged: (text) {
+                    setState(() {
+                      importButtonEnabled = text == 'import';
+                    });
+                  },
+                ),
+              ],
+            ),
+            actions: <Widget>[
+              TextButton(
+                child: const Text('Cancel'),
+                onPressed: () {
+                  Navigator.of(context).pop(false);
+                },
+              ),
+              ElevatedButton(
+                onPressed:
+                    importButtonEnabled
+                        ? () {
+                          Navigator.of(context).pop(true);
+                        }
+                        : null,
+                child: const Text('Import'),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+
+  if (importConfirmed == true) {
+    FilePickerResult? result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['db'],
+    );
+
+    if (result != null) {
+      String? pathToImport = result.files.single.path;
+
+      if (pathToImport != null) {
+        try {
+          await _performDatabaseImport(pathToImport);
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Data imported successfully!')),
+          );
+        } catch (e) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('Error importing data: $e')));
+        }
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Error: Could not get file path.')),
+        );
+      }
+    } else {
+      // User canceled the picker
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Import cancelled.')));
+    }
+  }
+}
+
+// AI!: this logic should be DatabaseHelper
+Future<void> _performDatabaseImport(String pathToImport) async {
+  final Database db = await DatabaseHelper.instance.database;
+  // Get the path to the application's database directory
+  String appDbPath = await DatabaseHelper.getPath();
+
+  // Delete the existing database
+  await db.close();
+  await deleteDatabase(appDbPath);
+
+  // Copy the selected database file to the application's database path
+  await File(pathToImport).copy(appDbPath);
+
+  // Re-open the database
+  await DatabaseHelper.instance.database;
+}

--- a/app/lib/data_importer.dart
+++ b/app/lib/data_importer.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:sqflite/sqflite.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:karriba/database_helper.dart';
 
@@ -15,21 +12,18 @@ Future<void> importDatabase(BuildContext context) async {
       return StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
           return AlertDialog(
-            title: const Text('Import Data?'),
+            title: const Text('Import Data'),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 const Text(
-                  'This will overwrite all existing data. Type "import" to continue.',
+                  'This will overwrite all existing data. Type "overwrite" to continue.',
                 ),
                 TextFormField(
                   controller: importCodeController,
-                  decoration: const InputDecoration(
-                    hintText: 'Type "import" here',
-                  ),
                   onChanged: (text) {
                     setState(() {
-                      importButtonEnabled = text == 'import';
+                      importButtonEnabled = text == 'overwrite';
                     });
                   },
                 ),
@@ -59,17 +53,14 @@ Future<void> importDatabase(BuildContext context) async {
   );
 
   if (importConfirmed == true) {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['db'],
-    );
+    FilePickerResult? result = await FilePicker.platform.pickFiles();
 
     if (result != null) {
       String? pathToImport = result.files.single.path;
 
       if (pathToImport != null) {
         try {
-          await DatabaseHelper.instance.performDatabaseImport(pathToImport);
+          await DatabaseHelper.instance.importDbFile(pathToImport);
 
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Data imported successfully!')),

--- a/app/lib/data_importer.dart
+++ b/app/lib/data_importer.dart
@@ -69,7 +69,7 @@ Future<void> importDatabase(BuildContext context) async {
 
       if (pathToImport != null) {
         try {
-          await _performDatabaseImport(pathToImport);
+          await DatabaseHelper.instance.performDatabaseImport(pathToImport);
 
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Data imported successfully!')),
@@ -91,21 +91,4 @@ Future<void> importDatabase(BuildContext context) async {
       ).showSnackBar(const SnackBar(content: Text('Import cancelled.')));
     }
   }
-}
-
-// AI!: this logic should be DatabaseHelper
-Future<void> _performDatabaseImport(String pathToImport) async {
-  final Database db = await DatabaseHelper.instance.database;
-  // Get the path to the application's database directory
-  String appDbPath = await DatabaseHelper.getPath();
-
-  // Delete the existing database
-  await db.close();
-  await deleteDatabase(appDbPath);
-
-  // Copy the selected database file to the application's database path
-  await File(pathToImport).copy(appDbPath);
-
-  // Re-open the database
-  await DatabaseHelper.instance.database;
 }

--- a/app/lib/database_helper.dart
+++ b/app/lib/database_helper.dart
@@ -76,19 +76,18 @@ class DatabaseHelper {
     }
   }
 
-  Future<void> performDatabaseImport(String pathToImport) async {
-    final Database db = await instance.database;
+  /* WARNING: this will replace the whole DB. All data will be lost. */
+  Future<void> importDbFile(String pathToImport) async {
+    final Database db = await database;
     // Get the path to the application's database directory
     String appDbPath = await getPath();
 
-    // Delete the existing database
+    // Close and delete the existing database
     await db.close();
+    _database = null;
     await deleteDatabase(appDbPath);
 
     // Copy the selected database file to the application's database path
     await File(pathToImport).copy(appDbPath);
-
-    // Re-open the database
-    await instance.database;
   }
 }

--- a/app/lib/database_helper.dart
+++ b/app/lib/database_helper.dart
@@ -1,5 +1,6 @@
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+import 'dart:io';
 
 class DatabaseHelper {
   static const _currentSchemaVersion = 2;
@@ -73,5 +74,21 @@ class DatabaseHelper {
         )
         ''');
     }
+  }
+
+  Future<void> performDatabaseImport(String pathToImport) async {
+    final Database db = await instance.database;
+    // Get the path to the application's database directory
+    String appDbPath = await getPath();
+
+    // Delete the existing database
+    await db.close();
+    await deleteDatabase(appDbPath);
+
+    // Copy the selected database file to the application's database path
+    await File(pathToImport).copy(appDbPath);
+
+    // Re-open the database
+    await instance.database;
   }
 }

--- a/app/lib/settings_page.dart
+++ b/app/lib/settings_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:iconify_flutter/iconify_flutter.dart';
 import 'package:iconify_flutter/icons/mdi.dart';
-import 'coming_soon_dialog.dart';
 import 'data_exporter.dart';
+import 'data_importer.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
@@ -15,10 +15,7 @@ class SettingsPage extends StatelessWidget {
           leading: const Iconify(Mdi.database_import),
           title: const Text('Import Data'),
           onTap: () {
-            showDialog(
-              context: context,
-              builder: (BuildContext context) => const ComingSoonDialog(),
-            );
+            importDatabase(context);
           },
         ),
         ListTile(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.5"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   fake_async:
     dependency: transitive
     description:
@@ -65,6 +73,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ee11ce89f8937c39181bc88d57a455972f7545b86150d8f287d0d9cf95bcdf0a
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -78,6 +102,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "5a1e6fb2c0561958d7e4c33574674bda7b77caaca7a33b758876956f2902eea3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.27"
   flutter_svg:
     dependency: transitive
     description:
@@ -88,6 +120,11 @@ packages:
     version: "2.0.17"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -376,6 +413,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.12.0"
   xml:
     dependency: transitive
     description:
@@ -386,4 +431,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.27.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   sqflite: ^2.3.0
   path: ^1.9.1
   intl: ^0.20.2
+  file_picker: ^9.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changes

- Allow the user to import from a previously exported DB file

## Testing

- Use the export feature to export your data
- Clear the app data in the Android app settings
- Check that the app has no records/applicators/customers
- Import the db file
- Check that the app has the correct records/applicators/customers

## Future

- We do no validation on the selected file. The user can replace their DB with an arbitrary file.
- In the future we should do some validation before using the file