### PR TITLE
feat: edit record pesticides

### DIFF
--- a/app/lib/pdf_generator.dart
+++ b/app/lib/pdf_generator.dart
@@ -3,9 +3,7 @@ import 'dart:io';
 import 'package:intl/intl.dart';
 import 'package:karriba/applicator_dao.dart';
 import 'package:karriba/customer_dao.dart';
-import 'package:karriba/pesticide/pesticide.dart';
 import 'package:karriba/pesticide/pesticide_dao.dart';
-import 'package:karriba/record_pesticide/record_pesticide.dart';
 import 'package:karriba/record_pesticide/record_pesticide_dao.dart';
 import 'package:open_file/open_file.dart';
 import 'package:path/path.dart' as path;
@@ -19,7 +17,9 @@ class PDFGenerator {
     final document = pdf.Document();
     final applicator = await ApplicatorDao().get(recordData.applicatorId);
     final customer = await CustomerDao().get(recordData.customerId);
-    final recordPesticides = await RecordPesticideDao().queryByRecordId(recordData.id!);
+    final recordPesticides = await RecordPesticideDao().queryByRecordId(
+      recordData.id!,
+    );
     final pesticides = await PesticideDao().queryAllRows();
 
     final formattedDate =
@@ -40,10 +40,14 @@ class PDFGenerator {
     final temperature = recordData.temperature;
     final temperatureValue =
         temperature == null ? '' : temperature.toStringAsFixed(1);
-    final pesticidesString = recordPesticides.map((rp) {
-      final name = pesticides.firstWhere((p) => p.id == rp.pesticideId).name ?? 'Unknown';
-      return '$name ${rp.rate} ${rp.rateUnit}';
-    }).join(', ');
+    final pesticidesString = recordPesticides
+        .map((rp) {
+          final name =
+              pesticides.firstWhere((p) => p.id == rp.pesticideId).name ??
+              'Unknown';
+          return '$name ${rp.rate} ${rp.rateUnit}';
+        })
+        .join(', ');
 
     document.addPage(
       pdf.Page(
@@ -105,7 +109,11 @@ class PDFGenerator {
                 recordData.sprayVolume.toString(),
                 suffix: "GPA",
               ),
-              _buildRowWithBottomBox("Pesticides", pesticidesString, height: 100),
+              _buildRowWithBottomBox(
+                "Pesticides",
+                pesticidesString,
+                height: 100,
+              ),
               _buildInlineRow("Wind Velocity", windVelocityValue),
               _buildInlineRow(
                 "Wind Direction",

--- a/app/lib/pdf_generator.dart
+++ b/app/lib/pdf_generator.dart
@@ -21,9 +21,10 @@ class PDFGenerator {
       recordData.id!,
     );
     final pesticides = await PesticideDao().queryAllRows();
+    final pesticidesMap = {for (var p in pesticides) p.id: p.name};
 
     final formattedDate =
-        DateFormat('yyyy-MM-dd').format(recordData.timestamp).toString();
+        DateFormat('MM-dd-yyyy').format(recordData.timestamp).toString();
     final formattedTime =
         DateFormat('HH_mm').format(recordData.timestamp).toString();
     final beforeSpeed = recordData.windSpeedBefore;
@@ -41,12 +42,10 @@ class PDFGenerator {
     final temperatureValue =
         temperature == null ? '' : temperature.toStringAsFixed(1);
     final pesticidesString = recordPesticides
-        .map((rp) {
-          final name =
-              pesticides.firstWhere((p) => p.id == rp.pesticideId).name ??
-              'Unknown';
-          return '$name ${rp.rate} ${rp.rateUnit}';
-        })
+        .map(
+          (rp) =>
+              '${pesticidesMap[rp.pesticideId] ?? 'Unknown'} ${rp.rate} ${rp.rateUnit}',
+        )
         .join(', ');
 
     document.addPage(
@@ -150,8 +149,6 @@ class PDFGenerator {
     double height = 24,
     String suffix = '',
   }) {
-    print(label);
-    print(value);
     return pdf.Padding(
       padding: pdf.EdgeInsets.symmetric(vertical: 4),
       child: pdf.Column(
@@ -169,8 +166,6 @@ class PDFGenerator {
   }
 
   pdf.Widget _buildInlineRow(String label, String value, {String suffix = ''}) {
-    print(label);
-    print(value);
     return pdf.Padding(
       padding: pdf.EdgeInsets.symmetric(vertical: 4),
       child: pdf.Row(

--- a/app/lib/record_pesticide/edit_record_pesticides.dart
+++ b/app/lib/record_pesticide/edit_record_pesticides.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:iconify_flutter/iconify_flutter.dart';
+import 'package:iconify_flutter/icons/mdi.dart';
+import 'package:karriba/pesticide/pesticide.dart';
+import 'package:karriba/pesticide/pesticide_dao.dart';
+import 'package:karriba/record_pesticide/record_pesticide.dart';
+import 'package:karriba/record_pesticide/record_pesticide_dao.dart';
+
+class EditRecordPesticidesPage extends StatefulWidget {
+  const EditRecordPesticidesPage({super.key, required this.recordId});
+
+  final int recordId;
+
+  @override
+  State<EditRecordPesticidesPage> createState() =>
+      _EditRecordPesticidesPageState();
+}
+
+class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
+  final _formKey = GlobalKey<FormState>();
+  final PesticideDao _pesticideDao = PesticideDao();
+  final RecordPesticideDao _recordPesticideDao = RecordPesticideDao();
+
+  List<Pesticide> _allPesticides = [];
+  List<RecordPesticide> _selectedPesticides = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPesticides();
+  }
+
+  Future<void> _loadPesticides() async {
+    List<Pesticide> pesticides = await _pesticideDao.queryAllRows();
+    List<RecordPesticide> selected = await _recordPesticideDao.queryByRecordId(
+      widget.recordId,
+    );
+    setState(() {
+      _allPesticides = pesticides;
+      _selectedPesticides = selected;
+    });
+  }
+
+  void _addPesticides(List<Pesticide> selectedPesticides) {
+    setState(() {
+      for (var pesticide in selectedPesticides) {
+        if (!_selectedPesticides.any((rp) => rp.pesticideId == pesticide.id)) {
+          _selectedPesticides.add(
+            RecordPesticide(
+              recordId: widget.recordId,
+              pesticideId: pesticide.id ?? 0,
+              rate: 0.0,
+              rateUnit: 'fl oz',
+            ),
+          );
+        }
+      }
+    });
+  }
+
+  void _showPesticideSelectionSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        List<Pesticide> selected = List.from(_allPesticides.where(
+              (p) => _selectedPesticides.any((rp) => rp.pesticideId == p.id),
+        ));
+
+        return StatefulBuilder(
+          builder: (context, setModalState) {
+            return Container(
+              padding: const EdgeInsets.all(16),
+              height: 400,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Select Pesticides',
+                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  ),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: _allPesticides.length,
+                      itemBuilder: (context, index) {
+                        final pesticide = _allPesticides[index];
+                        final isSelected =
+                        selected.any((p) => p.id == pesticide.id);
+
+                        return CheckboxListTile(
+                          title: Text(pesticide.name),
+                          value: isSelected,
+                          contentPadding: EdgeInsets.zero,
+                          onChanged: (checked) {
+                            setModalState(() {
+                              if (checked == true) {
+                                selected.add(pesticide);
+                              } else {
+                                selected.removeWhere((p) => p.id == pesticide.id);
+                              }
+                            });
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: () {
+                        _addPesticides(selected);
+                        Navigator.pop(context);
+                      },
+                      child: const Text('Confirm'),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _removePesticide(int pesticideId) async {
+    await _recordPesticideDao.delete(widget.recordId, pesticideId);
+    setState(() {
+      _selectedPesticides.removeWhere((rp) => rp.pesticideId == pesticideId);
+    });
+  }
+
+  Future<void> _saveRecord() async {
+    if (_formKey.currentState!.validate()) {
+      await _recordPesticideDao.saveAll(_selectedPesticides);
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => WillPopScope(
+    onWillPop: () async => true,
+    child: Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Pesticides'),
+        actions: [
+          IconButton(
+            icon: const Iconify(Mdi.content_save),
+            onPressed: _saveRecord,
+          ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            spacing: 16,
+            children: [
+              Expanded(
+                child: ListView.builder(
+                  itemCount: _selectedPesticides.length,
+                  itemBuilder: (context, index) {
+                    final recordPesticide = _selectedPesticides[index];
+                    final pesticide = _allPesticides.firstWhere(
+                          (p) => p.id == recordPesticide.pesticideId,
+                    );
+
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            flex: 2,
+                            child: Text(
+                              pesticide.name,
+                              style: const TextStyle(fontSize: 16),
+                            ),
+                          ),
+                          Expanded(
+                            flex: 2,
+                            child: TextFormField(
+                              decoration: const InputDecoration(
+                                labelText: 'Rate',
+                                border: OutlineInputBorder(),
+                              ),
+                              keyboardType: TextInputType.number,
+                              inputFormatters: [
+                                FilteringTextInputFormatter.allow(
+                                  RegExp(r'^\d*\.?\d*$'),
+                                ),
+                              ],
+                              initialValue: recordPesticide.rate.toString(),
+                              onChanged:
+                                  (value) =>
+                              recordPesticide.rate =
+                                  double.tryParse(value) ?? 0.0,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            flex: 2,
+                            child: DropdownButtonFormField<String>(
+                              value: recordPesticide.rateUnit,
+                              decoration: const InputDecoration(
+                                border: OutlineInputBorder(),
+                              ),
+                              items:
+                              const ['fl oz', 'oz', 'lb'].map((unit) {
+                                return DropdownMenuItem(
+                                  value: unit,
+                                  child: Text(unit),
+                                );
+                              }).toList(),
+                              onChanged:
+                                  (unit) => recordPesticide.rateUnit = unit!,
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.delete, color: Colors.red),
+                            onPressed:
+                                () => _removePesticide(
+                              recordPesticide.pesticideId,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _showPesticideSelectionSheet,
+        child: const Icon(Icons.add),
+      ),
+    ),
+  );
+}

--- a/app/lib/record_pesticide/edit_record_pesticides.dart
+++ b/app/lib/record_pesticide/edit_record_pesticides.dart
@@ -64,9 +64,11 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
       context: context,
       isScrollControlled: true,
       builder: (context) {
-        List<Pesticide> selected = List.from(_allPesticides.where(
-              (p) => _selectedPesticides.any((rp) => rp.pesticideId == p.id),
-        ));
+        List<Pesticide> selected = List.from(
+          _allPesticides.where(
+            (p) => _selectedPesticides.any((rp) => rp.pesticideId == p.id),
+          ),
+        );
 
         return StatefulBuilder(
           builder: (context, setModalState) {
@@ -85,8 +87,9 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
                       itemCount: _allPesticides.length,
                       itemBuilder: (context, index) {
                         final pesticide = _allPesticides[index];
-                        final isSelected =
-                        selected.any((p) => p.id == pesticide.id);
+                        final isSelected = selected.any(
+                          (p) => p.id == pesticide.id,
+                        );
 
                         return CheckboxListTile(
                           title: Text(pesticide.name),
@@ -97,7 +100,9 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
                               if (checked == true) {
                                 selected.add(pesticide);
                               } else {
-                                selected.removeWhere((p) => p.id == pesticide.id);
+                                selected.removeWhere(
+                                  (p) => p.id == pesticide.id,
+                                );
                               }
                             });
                           },
@@ -164,7 +169,7 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
                   itemBuilder: (context, index) {
                     final recordPesticide = _selectedPesticides[index];
                     final pesticide = _allPesticides.firstWhere(
-                          (p) => p.id == recordPesticide.pesticideId,
+                      (p) => p.id == recordPesticide.pesticideId,
                     );
 
                     return Padding(
@@ -194,8 +199,8 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
                               initialValue: recordPesticide.rate.toString(),
                               onChanged:
                                   (value) =>
-                              recordPesticide.rate =
-                                  double.tryParse(value) ?? 0.0,
+                                      recordPesticide.rate =
+                                          double.tryParse(value) ?? 0.0,
                             ),
                           ),
                           const SizedBox(width: 8),
@@ -207,12 +212,12 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
                                 border: OutlineInputBorder(),
                               ),
                               items:
-                              const ['fl oz', 'oz', 'lb'].map((unit) {
-                                return DropdownMenuItem(
-                                  value: unit,
-                                  child: Text(unit),
-                                );
-                              }).toList(),
+                                  const ['fl oz', 'oz', 'lb'].map((unit) {
+                                    return DropdownMenuItem(
+                                      value: unit,
+                                      child: Text(unit),
+                                    );
+                                  }).toList(),
                               onChanged:
                                   (unit) => recordPesticide.rateUnit = unit!,
                             ),
@@ -221,8 +226,8 @@ class _EditRecordPesticidesPageState extends State<EditRecordPesticidesPage> {
                             icon: const Icon(Icons.delete, color: Colors.red),
                             onPressed:
                                 () => _removePesticide(
-                              recordPesticide.pesticideId,
-                            ),
+                                  recordPesticide.pesticideId,
+                                ),
                           ),
                         ],
                       ),

--- a/app/lib/record_pesticide/record_pesticide.dart
+++ b/app/lib/record_pesticide/record_pesticide.dart
@@ -1,0 +1,58 @@
+class RecordPesticide {
+  final int recordId;
+  final int pesticideId;
+  double rate;
+  String rateUnit;
+
+  RecordPesticide({
+    required this.recordId,
+    required this.pesticideId,
+    required this.rate,
+    required this.rateUnit,
+  });
+
+  RecordPesticide copyWith({
+    int? recordId,
+    int? pesticideId,
+    double? rate,
+    String? rateUnit,
+  }) {
+    return RecordPesticide(
+      recordId: recordId ?? this.recordId,
+      pesticideId: pesticideId ?? this.pesticideId,
+      rate: rate ?? this.rate,
+      rateUnit: rateUnit ?? this.rateUnit,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'record_id': recordId,
+      'pesticide_id': pesticideId,
+      'rate': rate,
+      'rate_unit': rateUnit,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'RecordPesticide{recordId: $recordId, pesticideId: $pesticideId, rate: $rate, rateUnit: $rateUnit}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RecordPesticide &&
+          runtimeType == other.runtimeType &&
+          recordId == other.recordId &&
+          pesticideId == other.pesticideId &&
+          rate == other.rate &&
+          rateUnit == other.rateUnit;
+
+  @override
+  int get hashCode =>
+      recordId.hashCode ^
+      pesticideId.hashCode ^
+      rate.hashCode ^
+      rateUnit.hashCode;
+}

--- a/app/lib/record_pesticide/record_pesticide_dao.dart
+++ b/app/lib/record_pesticide/record_pesticide_dao.dart
@@ -1,0 +1,87 @@
+import 'package:karriba/database_helper.dart';
+import 'package:karriba/record_pesticide/record_pesticide.dart';
+import 'package:sqflite/sqflite.dart';
+
+class RecordPesticideDao {
+  final DatabaseHelper dbHelper = DatabaseHelper.instance;
+
+  Future<bool> _exists(int recordId, int pesticideId) async {
+    Database db = await dbHelper.database;
+    final List<Map<String, dynamic>> result = await db.query(
+      'record_pesticide',
+      where: 'record_id = ? AND pesticide_id = ?',
+      whereArgs: [recordId, pesticideId],
+    );
+    return result.isNotEmpty;
+  }
+
+  Future<int> save(RecordPesticide recordPesticide) async {
+    Database db = await dbHelper.database;
+    bool exists = await _exists(
+      recordPesticide.recordId,
+      recordPesticide.pesticideId,
+    );
+
+    if (exists) {
+      return await db.update(
+        'record_pesticide',
+        recordPesticide.toMap(),
+        where: 'record_id = ? AND pesticide_id = ?',
+        whereArgs: [recordPesticide.recordId, recordPesticide.pesticideId],
+      );
+    } else {
+      return await db.insert('record_pesticide', recordPesticide.toMap());
+    }
+  }
+
+  Future<void> saveAll(List<RecordPesticide> recordPesticides) async {
+    Database db = await dbHelper.database;
+    Batch batch = db.batch();
+
+    for (var recordPesticide in recordPesticides) {
+      bool exists = await _exists(
+        recordPesticide.recordId,
+        recordPesticide.pesticideId,
+      );
+      if (exists) {
+        batch.update(
+          'record_pesticide',
+          recordPesticide.toMap(),
+          where: 'record_id = ? AND pesticide_id = ?',
+          whereArgs: [recordPesticide.recordId, recordPesticide.pesticideId],
+        );
+      } else {
+        batch.insert('record_pesticide', recordPesticide.toMap());
+      }
+    }
+    await batch.apply();
+  }
+
+  Future<void> delete(int recordId, int pesticideId) async {
+    Database db = await dbHelper.database;
+    db.delete(
+      'record_pesticide',
+      where: 'record_id = ? AND pesticide_id = ?',
+      whereArgs: [recordId, pesticideId],
+    );
+  }
+
+  Future<List<RecordPesticide>> queryByRecordId(int recordId) async {
+    Database db = await dbHelper.database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'record_pesticide',
+      where: 'record_id = ?',
+      whereArgs: [recordId],
+    );
+
+    // Convert the List<Map<String, dynamic> into a List<RecordPesticide>.
+    return List.generate(maps.length, (i) {
+      return RecordPesticide(
+        recordId: maps[i]['record_id'] as int,
+        pesticideId: maps[i]['pesticide_id'] as int,
+        rate: maps[i]['rate'] as double,
+        rateUnit: maps[i]['rate_unit'] as String,
+      );
+    });
+  }
+}

--- a/app/lib/records_page.dart
+++ b/app/lib/records_page.dart
@@ -3,6 +3,7 @@ import 'package:iconify_flutter/iconify_flutter.dart';
 import 'package:iconify_flutter/icons/mdi.dart';
 import 'package:intl/intl.dart';
 import 'package:karriba/coming_soon_dialog.dart';
+import 'package:karriba/record_pesticide/edit_record_pesticides.dart';
 
 import 'edit_environmental_conditions_page.dart';
 import 'edit_record_page.dart';
@@ -129,10 +130,16 @@ class RecordTile extends StatelessWidget {
                   leading: Iconify(Mdi.bottle_tonic),
                   title: const Text('Pesticides'),
                   onTap: () async {
-                    await showDialog(
-                      context: context,
-                      builder: (context) => ComingSoonDialog(),
+                    Navigator.pop(context);
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder:
+                            (context) =>
+                                EditRecordPesticidesPage(recordId: record.id!),
+                      ),
                     );
+                    refresh();
                   },
                 ),
                 ListTile(

--- a/app/lib/settings_page.dart
+++ b/app/lib/settings_page.dart
@@ -25,7 +25,7 @@ class SettingsPage extends StatelessWidget {
           },
         ),
         ListTile(
-          leading: const Iconify(Mdi.bug),
+          leading: const Iconify(Mdi.bottle_tonic),
           title: const Text('Pesticides'),
           onTap: () {
             Navigator.push(


### PR DESCRIPTION
# Changes

- Implemented Record Pesticides editor. #74 
- Added pesticides information to PDF. #75 
- FIxed date format as per #87.
- Removed some leftover prints.

# Test

- Thorouhgly test pesticide record edition.
- Test that pesticides are correctly put in the PDF.

# Future

- Move pesticides editor to the record editor. Part of #78 
- Improve styling.